### PR TITLE
Extend measure to allow optional function args

### DIFF
--- a/lib/statix.ex
+++ b/lib/statix.ex
@@ -43,8 +43,8 @@ defmodule Statix do
       It returns the result of the function call, making it suitable
       for pipelining and easily wrapping existing code.
       """
-      def measure(key, fun, args \\ []) when is_function(fun) do
-        {time, result} = :timer.tc(fun, args)
+      def measure(key, fun) when is_function(fun, 0) do
+        {time, result} = :timer.tc(fun)
 
         timing(key, div(time, 1000))
 

--- a/lib/statix.ex
+++ b/lib/statix.ex
@@ -44,12 +44,12 @@ defmodule Statix do
       for pipelining and easily wrapping existing code.
       """
       # TODO: Use `:erlang.monotonic_time/1` when we depend on Elixir ~> 1.2
-      def measure(key, fun) when is_function(fun, 0) do
-        ts1 = :os.timestamp
-        result = fun.()
-        ts2 = :os.timestamp
-        elapsed_ms = :timer.now_diff(ts2, ts1) |> div(1000)
+      def measure(key, fun, args \\ []) when is_function(fun) do
+        {time, result} = :timer.tc(fun, args)
+
+        elapsed_ms = div(time, 1000)
         timing(key, elapsed_ms)
+
         result
       end
 

--- a/lib/statix.ex
+++ b/lib/statix.ex
@@ -43,12 +43,10 @@ defmodule Statix do
       It returns the result of the function call, making it suitable
       for pipelining and easily wrapping existing code.
       """
-      # TODO: Use `:erlang.monotonic_time/1` when we depend on Elixir ~> 1.2
       def measure(key, fun, args \\ []) when is_function(fun) do
         {time, result} = :timer.tc(fun, args)
 
-        elapsed_ms = div(time, 1000)
-        timing(key, elapsed_ms)
+        timing(key, div(time, 1000))
 
         result
       end

--- a/test/statix_test.exs
+++ b/test/statix_test.exs
@@ -101,18 +101,6 @@ defmodule StatixTest do
     assert fun_result == expected_result
   end
 
-  test "measure/3" do
-    expected_result = "the stuff."
-
-    fun_result = Sample.measure(["sample"], fn(result) ->
-      :timer.sleep(100)
-      result
-    end, [expected_result])
-
-    assert_receive {:server, <<"sample:10", _, "|ms">>}
-    assert fun_result == expected_result
-  end
-
   test "set/2" do
     Sample.set(["sample"], 2)
     assert_receive {:server, "sample:2|s"}

--- a/test/statix_test.exs
+++ b/test/statix_test.exs
@@ -96,6 +96,19 @@ defmodule StatixTest do
       :timer.sleep(100)
       expected_result
     end)
+
+    assert_receive {:server, <<"sample:10", _, "|ms">>}
+    assert fun_result == expected_result
+  end
+
+  test "measure/3" do
+    expected_result = "the stuff."
+
+    fun_result = Sample.measure(["sample"], fn(result) ->
+      :timer.sleep(100)
+      result
+    end, [expected_result])
+
     assert_receive {:server, <<"sample:10", _, "|ms">>}
     assert fun_result == expected_result
   end


### PR DESCRIPTION
Erlang's `:timer` module already has a function for timing the duration
of a function. By using it, we can also enable passing arguments to the
passed-in function.

Examples:

`measure("my_key", &Enum.map/2, [my_list, mapper_func])`
`measure("my_key", fn -> Enum.map(my_list, mapper_func) end)  # Maintains backwards compatibility`

This reports the duration of the map function, and returns the computed
value.

Optionally, we could also add a `measure/4` function which takes a key,
module, function, and args.

`measure("my_key", Enum, :map, [my_list, mapper_func])`

See http://erlang.org/doc/man/timer.html#tc-1