### PR TITLE
Fix race condition on UDP socket opening in tests

### DIFF
--- a/test/statix_test.exs
+++ b/test/statix_test.exs
@@ -18,7 +18,7 @@ defmodule StatixTest do
     end
 
     def handle_call({:set_current_test, current_test}, _from, %{test: test} = state) do
-      if is_nil(test) do
+      if is_nil(test) or is_nil(current_test) do
         {:reply, :ok, %{state | test: current_test}}      
       else
         {:reply, :error, state}      


### PR DESCRIPTION
The udp socket was asynchronously released on process exit but (because async) it could be still in use when the next test process starts. It would be better to explicitly close the socket at the end of each test. This could be done by closing the socket and monitoring the port termination as you can see in my previous pull request #15.
Given that this solution is based on erlang:monitor(port, ...) feature only available in erlang 18, the current PR opt for a different approach.

Just use a global gen_server Server for all the test suite. The socket is opened at the suite startup and never closed / reopen. This seems to me a more clean solution.

Note: it works under the hypothesis of a sequential (not parallel) tests execution, as already required by the current one, that is run: ```mix test --trace``` or ```mix test --max-cases=1```