### PR TITLE
Change Statix functions to be overridable

### DIFF
--- a/lib/statix.ex
+++ b/lib/statix.ex
@@ -313,6 +313,8 @@ defmodule Statix do
       def set(key, val, options \\ []) do
         Statix.transmit(current_conn(), :set, key, val, options)
       end
+
+      defoverridable [increment: 3, decrement: 3, gauge: 3, histogram: 3, timing: 3, measure: 3, set: 3]
     end
   end
 


### PR DESCRIPTION
First thing: thanks for this awesome lib :)

I found myself wanting to override the functions so that for example I can conditionally add some tags, change the key name etc. Would this be useful for others? 

I'm also not sure if the best solution is actually to make `transmit` part of the "main module" and make just that overridable?

And the tests are pretty much a copy and paste for now.

Thanks in advance :)