### PR TITLE
Fix deprecation message

### DIFF
--- a/lib/statix/conn.ex
+++ b/lib/statix/conn.ex
@@ -6,7 +6,7 @@ defmodule Statix.Conn do
   alias Statix.Packet
 
   def new(host, port) when is_binary(host) do
-    new(String.to_char_list(host), port)
+    new(String.to_charlist(host), port)
   end
 
   def new(host, port) when is_list(host) or is_tuple(host) do

--- a/lib/statix/conn.ex
+++ b/lib/statix/conn.ex
@@ -5,14 +5,8 @@ defmodule Statix.Conn do
 
   alias Statix.Packet
 
-  if Version.match?(System.version, ">= 1.4.0") do
-    def new(host, port) when is_binary(host) do
-      new(String.to_charlist(host), port)
-    end
-  else
-    def new(host, port) when is_binary(host) do
-      new(String.to_char_list(host), port)
-    end
+  def new(host, port) when is_binary(host) do
+    new(string_to_charlist(host), port)
   end
 
   def new(host, port) when is_list(host) or is_tuple(host) do
@@ -37,5 +31,11 @@ defmodule Statix.Conn do
     receive do
       {:inet_reply, _port, status} -> status
     end
+  end
+  
+  if Version.match?(System.version(), ">= 1.3.0") do
+    defp string_to_charlist(string), do: String.to_charlist(string)
+  else
+    defp string_to_charlist(string), do: String.to_char_list(string)
   end
 end

--- a/lib/statix/conn.ex
+++ b/lib/statix/conn.ex
@@ -5,8 +5,14 @@ defmodule Statix.Conn do
 
   alias Statix.Packet
 
-  def new(host, port) when is_binary(host) do
-    new(String.to_charlist(host), port)
+  if Version.match?(System.version, ">= 1.4.0") do
+    def new(host, port) when is_binary(host) do
+      new(String.to_charlist(host), port)
+    end
+  else
+    def new(host, port) when is_binary(host) do
+      new(String.to_char_list(host), port)
+    end
   end
 
   def new(host, port) when is_list(host) or is_tuple(host) do


### PR DESCRIPTION
String.to_char_list is deprecated and emits a message under Elixir >= 1.5.