### PR TITLE
Add support for global tags

### DIFF
--- a/lib/statix.ex
+++ b/lib/statix.ex
@@ -339,7 +339,7 @@ defmodule Statix do
       when (is_binary(key) or is_list(key)) and is_list(options) do
     sample_rate = Keyword.get(options, :sample_rate)
     if is_nil(sample_rate) or sample_rate >= :rand.uniform() do
-      Conn.transmit(conn, type, key, to_string(val), add_global_tags(options))
+      Conn.transmit(conn, type, key, to_string(val), add_global_tags(conn.sock, options))
     else
       :ok
     end
@@ -368,8 +368,16 @@ defmodule Statix do
     end
   end
 
-  defp add_global_tags(options) do
-    global_tags = Application.get_env(:statix, :tags, [])
+  defp add_global_tags(module, options) do
+    backend_tags =
+      :statix
+      |> Application.get_env(module, [])
+      |> Keyword.get(:tags, [])
+
+    application_tags = Application.get_env(:statix, :tags, [])
+
+    global_tags = backend_tags ++ application_tags
+
     Keyword.update(options, :tags, global_tags, &(&1 ++ global_tags))
   end
 

--- a/lib/statix.ex
+++ b/lib/statix.ex
@@ -50,6 +50,8 @@ defmodule Statix do
       Defaults to `"127.0.0.1"`.
     * `:port` - (integer) the port (on `:host`) where the StatsD-compatible
       server is running. Defaults to `8125`.
+    * `:tags` - ([binary]) a list of global tags that will be sent with all
+      metrics. If `nil`, no global tags will be set. Defaults to `nil`.
 
   By default, the configuration is evaluated once, at compile time. If you plan
   on changing the configuration at runtime, you must specify the
@@ -337,7 +339,7 @@ defmodule Statix do
       when (is_binary(key) or is_list(key)) and is_list(options) do
     sample_rate = Keyword.get(options, :sample_rate)
     if is_nil(sample_rate) or sample_rate >= :rand.uniform() do
-      Conn.transmit(conn, type, key, to_string(val), options)
+      Conn.transmit(conn, type, key, to_string(val), add_global_tags(options))
     else
       :ok
     end
@@ -365,4 +367,18 @@ defmodule Statix do
       {_p1, _p2} -> [part1, ?., part2, ?.]
     end
   end
+
+  defp add_global_tags(options) do
+    global_tags = Application.get_env(:statix, :tags)
+    options_tags = Keyword.get(options, :tags)
+
+    new_tags = cond do
+      options_tags && global_tags -> options_tags ++ global_tags
+      global_tags -> global_tags
+      true -> nil
+    end
+
+    if new_tags, do: Keyword.put(options, :tags, new_tags), else: options
+  end
+
 end

--- a/lib/statix.ex
+++ b/lib/statix.ex
@@ -369,16 +369,8 @@ defmodule Statix do
   end
 
   defp add_global_tags(options) do
-    global_tags = Application.get_env(:statix, :tags)
-    options_tags = Keyword.get(options, :tags)
-
-    new_tags = cond do
-      options_tags && global_tags -> options_tags ++ global_tags
-      global_tags -> global_tags
-      true -> nil
-    end
-
-    if new_tags, do: Keyword.put(options, :tags, new_tags), else: options
+    global_tags = Application.get_env(:statix, :tags, [])
+    Keyword.update(options, :tags, global_tags, &(&1 ++ global_tags))
   end
 
 end

--- a/lib/statix.ex
+++ b/lib/statix.ex
@@ -379,5 +379,4 @@ defmodule Statix do
 
     Keyword.update(options, :tags, global_tags, &(&1 ++ global_tags))
   end
-
 end

--- a/lib/statix/packet.ex
+++ b/lib/statix/packet.ex
@@ -42,6 +42,8 @@ defmodule Statix.Packet do
     [packet | ["|@", :erlang.float_to_binary(sample_rate, [:compact, decimals: 2])]]
   end
 
+  defp set_option(packet, :tags, []), do: packet
+
   defp set_option(packet, :tags, tags) when is_list(tags) do
     [packet | ["|#", Enum.join(tags, ",")]]
   end

--- a/test/statix_test.exs
+++ b/test/statix_test.exs
@@ -78,8 +78,6 @@ defmodule StatixTest do
     :ok = Server.set_current_test(self())
     TestStatix.connect
     OverridingStatix.connect
-    Application.delete_env(:statix, :tags)
-    Application.delete_env(:statix, TestStatix)
     on_exit(fn -> Server.set_current_test(nil) end)
   end
 
@@ -247,9 +245,11 @@ defmodule StatixTest do
 
     TestStatix.increment("sample", 3, tags: ["foo"])
     assert_receive {:server, "sample:3|c|#foo,tag:test"}
+  after
+    Application.delete_env(:statix, :tags)
   end
 
-  test "sends global backend-specific tags" do
+  test "sends global connection-specific tags" do
     Application.put_env(:statix, TestStatix, tags: ["tag:test"])
 
     TestStatix.increment("sample", 3)
@@ -257,6 +257,7 @@ defmodule StatixTest do
 
     TestStatix.increment("sample", 3, tags: ["foo"])
     assert_receive {:server, "sample:3|c|#foo,tag:test"}
+  after
+    Application.delete_env(:statix, TestStatix)
   end
-
 end

--- a/test/statix_test.exs
+++ b/test/statix_test.exs
@@ -79,6 +79,7 @@ defmodule StatixTest do
     TestStatix.connect
     OverridingStatix.connect
     Application.delete_env(:statix, :tags)
+    Application.delete_env(:statix, TestStatix)
     on_exit(fn -> Server.set_current_test(nil) end)
   end
 

--- a/test/statix_test.exs
+++ b/test/statix_test.exs
@@ -248,4 +248,14 @@ defmodule StatixTest do
     assert_receive {:server, "sample:3|c|#foo,tag:test"}
   end
 
+  test "sends global backend-specific tags" do
+    Application.put_env(:statix, TestStatix, tags: ["tag:test"])
+
+    TestStatix.increment("sample", 3)
+    assert_receive {:server, "sample:3|c|#tag:test"}
+
+    TestStatix.increment("sample", 3, tags: ["foo"])
+    assert_receive {:server, "sample:3|c|#foo,tag:test"}
+  end
+
 end

--- a/test/statix_test.exs
+++ b/test/statix_test.exs
@@ -78,7 +78,7 @@ defmodule StatixTest do
     :ok = Server.set_current_test(self())
     TestStatix.connect
     OverridingStatix.connect
-    Application.put_env(:statix, :tags, nil)
+    Application.delete_env(:statix, :tags)
     on_exit(fn -> Server.set_current_test(nil) end)
   end
 

--- a/test/statix_test.exs
+++ b/test/statix_test.exs
@@ -78,6 +78,7 @@ defmodule StatixTest do
     :ok = Server.set_current_test(self())
     TestStatix.connect
     OverridingStatix.connect
+    Application.put_env(:statix, :tags, nil)
     on_exit(fn -> Server.set_current_test(nil) end)
   end
 
@@ -236,4 +237,15 @@ defmodule StatixTest do
     OverridingStatix.set("sample", 3, tags: ["foo"])
     assert_receive {:server, "sample-overridden:3|s|#foo"}
   end
+
+  test "sends global tags when present" do
+    Application.put_env(:statix, :tags, ["tag:test"])
+
+    TestStatix.increment("sample", 3)
+    assert_receive {:server, "sample:3|c|#tag:test"}
+
+    TestStatix.increment("sample", 3, tags: ["foo"])
+    assert_receive {:server, "sample:3|c|#foo,tag:test"}
+  end
+
 end


### PR DESCRIPTION
This PR adds the ability to configure Statix with global tags, fixing [#13](https://github.com/lexmag/statix/issues/13).