### PR TITLE
Events & Service checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ end
 
 Once the Statix connection is open, its `increment/1,2`, `decrement/1,2`, `gauge/2`, `set/2`, `timing/2`, and `measure/2` functions can be used to push metrics to the StatsD-compatible server.
 
+`event/2,3` and `service_check/2,3` are DataDog StatsD protocol extensions not supported by standard StatsD servers.
+
 ### Sampling
 
 Sampling is supported via the `:sample_rate` option:
@@ -81,6 +83,8 @@ MyApp.Statix.increment("page_view", 1, sample_rate: 0.5)
 
 The UDP packet will only be sent to the server about half of the time,
 but the resulting value will be adjusted on the server according to the given sample rate.
+
+NOTE: sampling is applied to all functions except `event/2,3` and `service_check/2,3`.
 
 ### Tags
 

--- a/lib/statix.ex
+++ b/lib/statix.ex
@@ -87,6 +87,25 @@ defmodule Statix do
   @type options :: [sample_rate: float, tags: [String.t()]]
   @type on_send :: :ok | {:error, term}
 
+  @type event_options :: [
+          timestamp: integer,
+          hostname: String.t(),
+          aggregation_key: String.t(),
+          priority: :low | :normal,
+          source_type_name: String.t(),
+          alert_type: :error | :warning | :info | :success,
+          tags: [String.t()]
+        ]
+
+  @type service_check_options :: [
+          timestamp: integer,
+          hostname: String.t(),
+          message: String.t(),
+          tags: [String.t()]
+        ]
+
+  @type service_check_status :: :ok | :warning | :critical | :unknown
+
   @doc """
   Opens the connection to the StatsD-compatible server.
 
@@ -232,6 +251,17 @@ defmodule Statix do
   """
   @callback measure(key, function :: (() -> result)) :: result when result: var
 
+  @doc """
+  Emits event to the event stream (note: this is a DataDog StatsD protocol extension).
+  """
+  @callback event(title :: String.t(), text :: String.t(), event_options) :: on_send
+
+  @doc """
+  Sends service checks to DataDog (note: this is a DataDog StatsD protocol extension).
+  """
+  @callback service_check(name :: String.t(), service_check_status, service_check_options) ::
+              on_send
+
   defmacro __using__(opts) do
     current_conn =
       if Keyword.get(opts, :runtime_config, false) do
@@ -317,6 +347,14 @@ defmodule Statix do
         Statix.transmit(current_conn(), :set, key, val, options)
       end
 
+      def event(title, text, options \\ []) do
+        Statix.transmit(current_conn(), :event, title, text, options)
+      end
+
+      def service_check(name, status, options \\ []) do
+        Statix.transmit(current_conn(), :service_check, name, status, options)
+      end
+
       defoverridable(
         increment: 3,
         decrement: 3,
@@ -324,7 +362,9 @@ defmodule Statix do
         histogram: 3,
         timing: 3,
         measure: 3,
-        set: 3
+        set: 3,
+        event: 3,
+        service_check: 3
       )
     end
   end
@@ -341,6 +381,18 @@ defmodule Statix do
   def open_conn(%Conn{sock: module} = conn) do
     conn = Conn.open(conn)
     Process.register(conn.sock, module)
+  end
+
+  @doc false
+  def transmit(conn, :event, title, text, options)
+      when is_binary(title) and is_binary(text) and is_list(options) do
+    Conn.transmit(conn, :event, title, text, options)
+  end
+
+  @doc false
+  def transmit(conn, :service_check, name, status, options)
+      when is_binary(name) and is_atom(status) and is_list(options) do
+    Conn.transmit(conn, :service_check, name, to_string(status), options)
   end
 
   @doc false

--- a/lib/statix/packet.ex
+++ b/lib/statix/packet.ex
@@ -18,6 +18,28 @@ defmodule Statix.Packet do
       ]
   end
 
+  def build(header, :event, title, text, options) do
+    title_len = title |> String.length() |> Integer.to_string
+    text_len = text |> String.length() |> Integer.to_string
+    [header, "_e{", title_len, ",", text_len, "}:", title, "|", text]
+    |> set_ext_option("d", options[:timestamp])
+    |> set_ext_option("h", options[:hostname])
+    |> set_ext_option("k", options[:aggregation_key])
+    |> set_ext_option("p", options[:priority])
+    |> set_ext_option("s", options[:source_type_name])
+    |> set_ext_option("t", options[:alert_type])
+    |> set_option(:tags, options[:tags])
+  end
+
+  def build(header, :service_check, name, status, options) do
+    [header, "_sc|", name]
+    |> set_service_check_status(status)
+    |> set_ext_option("d", options[:timestamp])
+    |> set_ext_option("h", options[:hostname])
+    |> set_option(:tags, options[:tags])
+    |> set_ext_option("m", options[:message])
+  end
+
   def build(header, name, key, val, options) do
     [header, key, ?:, val, ?|, metric_type(name)]
     |> set_option(:sample_rate, options[:sample_rate])
@@ -48,5 +70,25 @@ defmodule Statix.Packet do
 
   defp set_option(packet, :tags, tags) when is_list(tags) do
     [packet | ["|#", Enum.join(tags, ",")]]
+  end
+
+  defp set_ext_option(packet, _opt_key, nil) do
+    packet
+  end
+
+  defp set_ext_option(packet, opt_key, value) do
+    [packet | [?|, opt_key, ?:, to_string(value)]]
+  end
+
+  defp set_service_check_status(packet, status) do
+    stat =
+      case status do
+        "ok" -> ?0
+        "warning" -> ?1
+        "critical" -> ?2
+        "unknown" -> ?3
+        _ -> ?3
+      end
+    [packet | [?|, stat]]
   end
 end

--- a/lib/statix/packet.ex
+++ b/lib/statix/packet.ex
@@ -19,8 +19,8 @@ defmodule Statix.Packet do
   end
 
   def build(header, :event, title, text, options) do
-    title_len = title |> String.length() |> Integer.to_string
-    text_len = text |> String.length() |> Integer.to_string
+    title_len = title |> String.length() |> Integer.to_string()
+    text_len = text |> String.length() |> Integer.to_string()
     [header, "_e{", title_len, ",", text_len, "}:", title, "|", text]
     |> set_ext_option("d", options[:timestamp])
     |> set_ext_option("h", options[:hostname])

--- a/lib/statix/packet.ex
+++ b/lib/statix/packet.ex
@@ -21,6 +21,7 @@ defmodule Statix.Packet do
   def build(header, :event, title, text, options) do
     title_len = title |> String.length() |> Integer.to_string()
     text_len = text |> String.length() |> Integer.to_string()
+
     [header, "_e{", title_len, ",", text_len, "}:", title, "|", text]
     |> set_ext_option("d", options[:timestamp])
     |> set_ext_option("h", options[:hostname])
@@ -89,6 +90,7 @@ defmodule Statix.Packet do
         "unknown" -> ?3
         _ -> ?3
       end
+
     [packet | [?|, stat]]
   end
 end

--- a/test/statix_test.exs
+++ b/test/statix_test.exs
@@ -228,7 +228,8 @@ defmodule StatixTest do
   end
 
   test "event/2,3" do
-    now_unix = DateTime.utc_now() |> DateTime.to_unix()
+    # a generic Unix time
+    now_unix = 1234
 
     TestStatix.event("sample title", "sample text")
     assert_receive {:server, "_e{12,11}:sample title|sample text"}
@@ -272,7 +273,8 @@ defmodule StatixTest do
   end
 
   test "service_check/2,3" do
-    now_unix = DateTime.utc_now() |> DateTime.to_unix()
+    # a generic Unix time
+    now_unix = 1234
 
     TestStatix.service_check("sample name", :ok)
     assert_receive {:server, "_sc|sample name|0"}


### PR DESCRIPTION
This PR adds the much wanted access to datadog statsd extensions from statix:

Events: https://docs.datadoghq.com/developers/dogstatsd/#events-1
Service checks: https://docs.datadoghq.com/developers/dogstatsd/#service-checks-1

This basically is a sync https://github.com/lexmag/statix/pull/14 from @visciang with latest master.