### PR TITLE
Make Statix.Conn.transmit/2 public

### DIFF
--- a/lib/statix/conn.ex
+++ b/lib/statix/conn.ex
@@ -26,7 +26,7 @@ defmodule Statix.Conn do
     |> transmit(conn.sock)
   end
 
-  defp transmit(packet, sock) do
+  def transmit(packet, sock) do
     Port.command(sock, packet)
 
     receive do


### PR DESCRIPTION
This PR opens the function `Statix.Conn.transmit(packet, sock)`, allowing other kinds of packets to be transmitted without needing to extend the library.

Originated from https://github.com/lexmag/statix/pull/26#issuecomment-394025014