### PR TITLE
Fix defoverridable to take into account default parameters

### DIFF
--- a/lib/statix.ex
+++ b/lib/statix.ex
@@ -313,7 +313,22 @@ defmodule Statix do
         Statix.transmit(current_conn(), :set, key, val, options)
       end
 
-      defoverridable [increment: 3, decrement: 3, gauge: 3, histogram: 3, timing: 3, measure: 3, set: 3]
+      defoverridable increment: 1,
+                     increment: 2,
+                     increment: 3,
+                     decrement: 1,
+                     decrement: 2,
+                     decrement: 3,
+                     gauge: 2,
+                     gauge: 3,
+                     histogram: 2,
+                     histogram: 3,
+                     timing: 2,
+                     timing: 3,
+                     measure: 2,
+                     measure: 3,
+                     set: 2,
+                     set: 3
     end
   end
 


### PR DESCRIPTION
As pointed out [here](https://github.com/elixir-lang/elixir/issues/3612), when using default parameters and `defoverridable`, you have to also define the overridable arity for each potential default parameter version of the method(since the compiled version does create each level of arity function).

This adds that.